### PR TITLE
ステータスを数字ではなく、文字で表現する

### DIFF
--- a/src/components/InputBookForm.tsx
+++ b/src/components/InputBookForm.tsx
@@ -229,9 +229,9 @@ export default function InputBookForm(props: Props) {
               value={book.status}
               onChange={changeStatus}
             >
-              <option value={0}>読んでない</option>
-              <option value={1}>読んだ</option>
-              <option value={2}>読書中</option>
+              <option value={"読んでいない"}>読んでない</option>
+              <option value={"読んだ"}>読んだ</option>
+              <option value={"読書中"}>読書中</option>
             </NativeSelect>
           </TableRow>
           <TableRow className={classes.tableRow}>


### PR DESCRIPTION
## 背景
現状ステータスが0,1,2と数字で表示されているためどんな状態なのかがわかりにくい
そのため以下の表示に切り替える
0 → 読んでいない
1 → 読んだ
2 → 読書中

## 実装内容
- [x] optionタグのvalueを切り替える