### PR TITLE
要点・感想の残り文字数をリアルタイムに表示する機能の作成

### DIFF
--- a/src/components/InputBookForm.tsx
+++ b/src/components/InputBookForm.tsx
@@ -42,6 +42,9 @@ const useStyles = makeStyles((theme: Theme) =>
     submit: {
       margin: theme.spacing(2),
       width: 150
+    },
+    wordCount: {
+      margin: theme.spacing(2)
     }
   })
 )
@@ -54,6 +57,8 @@ aws.config.update({
 
 export default function InputBookForm(props: Props) {
   const classes = useStyles({})
+  const gistMaxLength = 5000
+  const impressionMaxLength = 10000
   const [book, setBook] = useState({
     title: '',
     author: '',
@@ -61,7 +66,9 @@ export default function InputBookForm(props: Props) {
     status: '',
     gist: '',
     impression: '',
-    image: ''
+    image: '',
+    gistWordCount: 0,
+    impressionWordCount: 0
   })
   useEffect(() => {
     getEdit()
@@ -87,10 +94,20 @@ export default function InputBookForm(props: Props) {
     setBook({ ...book, status: event.target.value })
   }
   function changeGist(event: React.ChangeEvent<HTMLInputElement>) {
-    setBook({ ...book, gist: event.target.value })
+    if(event.target.value.length > gistMaxLength){
+      event.target.style.color = 'red'
+    } else {
+      event.target.style.color = 'black'
+    }
+    setBook({ ...book, gist: event.target.value, gistWordCount: event.target.value.length })
   }
   function changeImpression(event: React.ChangeEvent<HTMLInputElement>) {
-    setBook({ ...book, impression: event.target.value })
+    if(event.target.value.length > impressionMaxLength){
+      event.target.style.color = 'red'
+    } else {
+      event.target.style.color = 'black'
+    }
+    setBook({ ...book, impression: event.target.value, impressionWordCount: event.target.value.length })
   }
   function changeImage(event: React.ChangeEvent<HTMLInputElement>) {
     // nullチェック必須(ts)
@@ -236,6 +253,7 @@ export default function InputBookForm(props: Props) {
           </TableRow>
           <TableRow className={classes.tableRow}>
             <TableCell className={classes.tableCell}>要点</TableCell>
+            <p className={classes.wordCount}>{`${book.gistWordCount}/5000`}</p>
             <TextField
               id="filled-multiline-static"
               label="要点"
@@ -249,6 +267,7 @@ export default function InputBookForm(props: Props) {
           </TableRow>
           <TableRow className={classes.tableRow}>
             <TableCell className={classes.tableCell}>感想</TableCell>
+            <p className={classes.wordCount}>{`${book.impressionWordCount}/10000`}</p>
             <TextField
               id="filled-multiline-static"
               label="感想"

--- a/src/components/InputBookForm.tsx
+++ b/src/components/InputBookForm.tsx
@@ -253,7 +253,7 @@ export default function InputBookForm(props: Props) {
           </TableRow>
           <TableRow className={classes.tableRow}>
             <TableCell className={classes.tableCell}>要点</TableCell>
-            <p className={classes.wordCount}>{`${book.gistWordCount}/5000`}</p>
+            <p className={classes.wordCount}>{`${book.gistWordCount}/${gistMaxLength}`}</p>
             <TextField
               id="filled-multiline-static"
               label="要点"
@@ -267,7 +267,7 @@ export default function InputBookForm(props: Props) {
           </TableRow>
           <TableRow className={classes.tableRow}>
             <TableCell className={classes.tableCell}>感想</TableCell>
-            <p className={classes.wordCount}>{`${book.impressionWordCount}/10000`}</p>
+            <p className={classes.wordCount}>{`${book.impressionWordCount}/${impressionMaxLength}`}</p>
             <TextField
               id="filled-multiline-static"
               label="感想"


### PR DESCRIPTION
## 背景
実際に書籍新規作成画面を使ってみて残りの文字数が表示されていないと保存した時に登録できないため。
あと、何が原因で登録できていないのかフロント画面からは分からない
そのため記述できる残り文字数をリアルタイムで表示すればわかりやすいと思った。
プラス書籍内容をまとめるのにも役立つ(残り文字数がこれぐらいだから何を書こうかを思考できる)

## 実装方法
- [x] テキストエリアの文字数をカウント
- [x] カウントした文字数をリアルタイムでカウント
- [x] 文字数が上限を超えたら文字色を赤色にする